### PR TITLE
Add support for kubernetes 1.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ Supported Kubernetes versions:
   - 1.7.10
   - 1.8.0
   - 1.8.4
+  - 1.8.6

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "check_kops_version" {
   provisioner "local-exec" {
-    command = "kops version | grep -q ${local.supported_kops_version} || echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'"
+    command = "if [[ ! $(kops version | cut -d ' ' -f2 | cut -c 1-3 ) -eq ${local.supported_kops_version} ]]; then echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'; exit 1; fi"
   }
 }
 

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "check_kops_version" {
   provisioner "local-exec" {
-    command = "if [[ ! $(kops version | cut -d ' ' -f2 | cut -c 1-3 ) -eq ${local.supported_kops_version} ]]; then echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'; exit 1; fi"
+    command = "if [[ ! $(kops version | cut -d ' ' -f2 | cut -c 1-3 ) = ${local.supported_kops_version} ]]; then echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'; exit 1; fi"
   }
 }
 

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Currently support kops version
-  supported_kops_version = "1.8.0"
+  supported_kops_version = "1.8"
 
   # Removes the last character of the FQDN if it is '.'
   cluster_fqdn = "${replace(var.cluster_fqdn, "/\\.$/", "")}"

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -19,6 +19,16 @@ locals {
 
 locals {
   k8s_versions = {
+    "1.8.6" = {
+      kubelet_hash   = "96c23396f0bb67fae0da843cc5765d0e8411e552"
+      kubectl_hash   = "59f138a5144224cb0c8ed440d3a0a0e91ef01271"
+      cni_hash       = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
+      cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
+      utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
+      protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
+      ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
+      docker_version = "1.13.1"
+    }
     "1.8.4" = {
       kubelet_hash   = "125993c220d1a9b5b60ad20a867a0e7cda63e64c"
       kubectl_hash   = "8e2314db816b9b4465c5f713c1152cb0603db15e"
@@ -26,7 +36,7 @@ locals {
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
       utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
       protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
-      ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02"
+      ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
       docker_version = "1.13.1"
     }
     "1.8.0" = {
@@ -36,7 +46,7 @@ locals {
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
       utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
       protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
-      ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02"
+      ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
       docker_version = "1.13.1"
     }
     "1.7.10" = {


### PR DESCRIPTION
Just adds a another entry to the K8s version map. Checked the hashes and version by creating a new cluster with 
```
kops create cluster --cloud=aws --dns public --authorization RBAC --networking calico --zones=ap-southeast-2a,ap-southeast-2b,ap-southeast-2c --node-count=1 --master-zones=ap-southeast-2a,ap-southeast-2b,ap-southeast-2c --target=terraform --api-loadbalancer-type=public --vpc=vpc-12345678 --state=s3://kops-bucket-example-org --kubernetes-version 1.8.6 mycluster.example.org
```
and looking through the userdata.

I also updated the AMI for older 1.8.x versions.

Should probably look at adding 1.9.x support as soon as I've had a play around with that.