### PR TITLE
Reverting changes from previous PR that broke everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Authentication: RBAC only
 
 Networking: calico or flannel
 
-Kops version: 1.8.0
+Kops version: 1.8.1
 
 Supported Kubernetes versions:
   - 1.7.10

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # To do
 
 - Support extra user-data
-- Have option to choose master count as one US region has 6x AZs. If AZ count is even, do AZ count -1.
-- Support 3 masters in 2x AZ regions
-- Add cloudwatch alarms for everything
+- Changes to number of masters:
+  - Support 3 masters in 2x AZ regions
+  - Allow to manually set master count
+  - If AZ count is even, do AZ count -1

--- a/example/kops_clusters.tf
+++ b/example/kops_clusters.tf
@@ -3,7 +3,7 @@
 
 module "cluster1" {
   source                    = "../module"
-  kubernetes_version        = "1.8.4"
+  kubernetes_version        = "1.8.6"
   sg_allow_ssh              = "${aws_security_group.allow_ssh.id}"
   sg_allow_http_s           = "${aws_security_group.allow_http.id}"
   cluster_name              = "cluster1"

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "check_kops_version" {
   provisioner "local-exec" {
-    command = "if [[ ! $(kops version | cut -d ' ' -f2 | cut -c 1-3 ) = ${local.supported_kops_version} ]]; then echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'; exit 1; fi"
+    command = "kops version | grep -q ${local.supported_kops_version} || echo 'Unsupported kops version. Version ${local.supported_kops_version} must be used'"
   }
 }
 

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Currently support kops version
-  supported_kops_version = "1.8"
+  supported_kops_version = "1.8.1"
 
   # Removes the last character of the FQDN if it is '.'
   cluster_fqdn = "${replace(var.cluster_fqdn, "/\\.$/", "")}"
@@ -30,8 +30,8 @@ locals {
       kubectl_hash   = "59f138a5144224cb0c8ed440d3a0a0e91ef01271"
       cni_hash       = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
-      utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
-      protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
+      utils_hash     = "42b15a0a0a56531750bde3c7b08d0cf27c170c48"
+      protokube_hash = "0b1f26208f8f6cc02468368706d0236670fec8a2"
       ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
       docker_version = "1.13.1"
     }

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -40,8 +40,8 @@ locals {
       kubectl_hash   = "8e2314db816b9b4465c5f713c1152cb0603db15e"
       cni_hash       = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
-      utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
-      protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
+      utils_hash     = "42b15a0a0a56531750bde3c7b08d0cf27c170c48"
+      protokube_hash = "0b1f26208f8f6cc02468368706d0236670fec8a2"
       ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
       docker_version = "1.13.1"
     }
@@ -51,8 +51,8 @@ locals {
       kubectl_hash   = "006fd43085e6ba2dc6b35b89af4d68cee3f689c9"
       cni_hash       = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
-      utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
-      protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
+      utils_hash     = "42b15a0a0a56531750bde3c7b08d0cf27c170c48"
+      protokube_hash = "0b1f26208f8f6cc02468368706d0236670fec8a2"
       ami_name       = "k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14"
       docker_version = "1.13.1"
     }
@@ -62,8 +62,8 @@ locals {
       kubectl_hash   = "4c174128ad3657bb09c5b3bd4a05565956b44744"
       cni_hash       = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
       cni_file_name  = "cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
-      utils_hash     = "f62360d3351bed837ae3ffcdee65e9d57511695a"
-      protokube_hash = "1b972e92520b3cafd576893ae3daeafdd1bc9ffd"
+      utils_hash     = "42b15a0a0a56531750bde3c7b08d0cf27c170c48"
+      protokube_hash = "0b1f26208f8f6cc02468368706d0236670fec8a2"
       ami_name       = "k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02"
       docker_version = "1.12.6"
     }

--- a/module/outputs.tf
+++ b/module/outputs.tf
@@ -65,3 +65,7 @@ output "nodes_role_arn" {
 output "nodes_role_name" {
   value = "${aws_iam_role.nodes.name}"
 }
+
+output "master_azs" {
+  value = "${local.master_azs}"
+}


### PR DESCRIPTION
For for this error:
```
== Failed to curl https://kubeupv2.s3.amazonaws.com/kops/1.8/linux/amd64/nodeup.sha1. Retrying. ==
All downloads failed; sleeping before retrying
```

And this error:

```
Hash did not match for "/var/cache/nodeup/sha1:f62360d3351bed837ae3ffcdee65e9d57511695a_https___kubeupv2_s3_amazonaws_com_kops_1_8_1_linux_amd64_utils_tar_gz": actual=sha1:42b15a0a0a56531750bde3c7b08d0cf27c170c48 vs expected=sha1:f62360d3351bed837ae3ffcdee65e9d57511695a
```