### PR TITLE
Adding option to set spot node instance type.

### DIFF
--- a/module/nodes.tf
+++ b/module/nodes.tf
@@ -137,7 +137,7 @@ resource "aws_launch_configuration" "node_spot" {
 
   name_prefix          = "${var.cluster_name}-node-spot"
   image_id             = "${data.aws_ami.k8s_ami.id}"
-  instance_type        = "${var.node_instance_type}"
+  instance_type        = "${var.spot_node_instance_type}"
   key_name             = "${var.instance_key_name}"
   spot_price           = "${var.max_price_spot}"
   iam_instance_profile = "${aws_iam_instance_profile.nodes.name}"

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -46,6 +46,11 @@ variable "master_instance_type" {
 
 # Instance type for nodes
 variable "node_instance_type" {
+  default = "c4.xlarge"
+}
+
+# Spot node instance type
+variable "spot_node_instance_type" {
   default = "c4.large"
 }
 


### PR DESCRIPTION
Addes the variable "spot_node_instance_type", so is going to be possible to use different types pf instances in On demand and Spot.