### PR TITLE
Refactor handling the master count and master AZs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,3 @@
 # To do
 
 - Support extra user-data
-- Changes to number of masters:
-  - Support 3 masters in 2x AZ regions
-  - Allow to manually set master count
-  - If AZ count is even, do AZ count -1

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -8,12 +8,34 @@ resource "null_resource" "create_cluster" {
   depends_on = ["null_resource.check_kops_version"]
 
   provisioner "local-exec" {
-    command = "kops create cluster --cloud=aws --dns ${var.kops_dns_mode} --authorization RBAC --networking ${var.kubernetes_networking} --zones=${join(",", data.aws_availability_zones.available.names)} --node-count=${var.node_asg_desired} --master-zones=${local.master_azs} --target=terraform --api-loadbalancer-type=public --vpc=${var.vpc_id} --ssh-public-key ${var.ssh_public_key_path} --state=s3://${var.kops_s3_bucket_id} --kubernetes-version ${var.kubernetes_version} ${local.cluster_fqdn}"
+    command = <<EOT
+      kops create cluster \
+      --cloud=aws \
+      --dns ${var.kops_dns_mode} \
+      --authorization RBAC \
+      --networking ${var.kubernetes_networking} \
+      --zones=${join(",", data.aws_availability_zones.available.names)} \
+      --node-count=${var.node_asg_desired} \
+      --master-zones=${local.master_azs} \
+      --target=terraform \
+      --api-loadbalancer-type=public \
+      --vpc=${var.vpc_id} \
+      --ssh-public-key ${var.ssh_public_key_path} \
+      --state=s3://${var.kops_s3_bucket_id} \
+      --kubernetes-version ${var.kubernetes_version} \
+      ${local.cluster_fqdn}
+    EOT
   }
 
   provisioner "local-exec" {
     when    = "destroy"
-    command = "kops delete cluster --yes --state=s3://${var.kops_s3_bucket_id} --unregister ${local.cluster_fqdn}"
+    command = <<EOT
+      kops delete cluster \
+      --state=s3://${var.kops_s3_bucket_id} \
+      --unregister \
+      --yes \
+      ${local.cluster_fqdn}
+    EOT
   }
 }
 

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -16,8 +16,10 @@ resource "null_resource" "create_cluster" {
       --networking ${var.kubernetes_networking} \
       --zones=${join(",", local.az_names)} \
       --node-count=${var.node_asg_desired} \
+      --node-size=${var.node_instance_type} \
       --master-zones=${join(",", local.master_azs)} \
       --master-count=${var.master_count} \
+      --master-size=${var.master_instance_type} \
       --target=terraform \
       --api-loadbalancer-type=public \
       --vpc=${var.vpc_id} \

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -37,6 +37,10 @@ resource "null_resource" "create_cluster" {
       ${local.cluster_fqdn}
     EOT
   }
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "null_resource" "delete_tf_files" {

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -14,9 +14,10 @@ resource "null_resource" "create_cluster" {
       --dns ${var.kops_dns_mode} \
       --authorization RBAC \
       --networking ${var.kubernetes_networking} \
-      --zones=${join(",", data.aws_availability_zones.available.names)} \
+      --zones=${join(",", local.az_names)} \
       --node-count=${var.node_asg_desired} \
-      --master-zones=${local.master_azs} \
+      --master-zones=${join(",", local.master_azs)} \
+      --master-count=${var.master_count} \
       --target=terraform \
       --api-loadbalancer-type=public \
       --vpc=${var.vpc_id} \

--- a/module/kops.tf
+++ b/module/kops.tf
@@ -8,7 +8,7 @@ resource "null_resource" "create_cluster" {
   depends_on = ["null_resource.check_kops_version"]
 
   provisioner "local-exec" {
-    command = "kops create cluster --cloud=aws --dns ${var.kops_dns_mode} --authorization RBAC --networking ${var.kubernetes_networking} --zones=${join(",", data.aws_availability_zones.available.names)} --node-count=${var.node_asg_desired} --master-zones=${local.master_azs} --target=terraform --api-loadbalancer-type=public --vpc=${var.vpc_id} --state=s3://${var.kops_s3_bucket_id} --kubernetes-version ${var.kubernetes_version} ${local.cluster_fqdn}"
+    command = "kops create cluster --cloud=aws --dns ${var.kops_dns_mode} --authorization RBAC --networking ${var.kubernetes_networking} --zones=${join(",", data.aws_availability_zones.available.names)} --node-count=${var.node_asg_desired} --master-zones=${local.master_azs} --target=terraform --api-loadbalancer-type=public --vpc=${var.vpc_id} --ssh-public-key ${var.ssh_public_key_path} --state=s3://${var.kops_s3_bucket_id} --kubernetes-version ${var.kubernetes_version} ${local.cluster_fqdn}"
   }
 
   provisioner "local-exec" {

--- a/module/masters_user_data.tf
+++ b/module/masters_user_data.tf
@@ -1,5 +1,5 @@
 data "template_file" "master_user_data_1" {
-  count    = "${local.master_resource_count}"
+  count    = "${var.master_count}"
   template = "${file("${path.module}/user_data/01_nodeup_url.sh.tpl")}"
 
   vars {
@@ -8,19 +8,19 @@ data "template_file" "master_user_data_1" {
 }
 
 data "template_file" "master_user_data_3" {
-  count    = "${local.master_resource_count}"
+  count    = "${var.master_count}"
   template = "${file("${path.module}/user_data/03_master_cluster_spec.sh.tpl")}"
 
   vars {
     kubernetes_version = "${var.kubernetes_version}"
-    master_count       = "${local.master_resource_count}"
+    master_count       = "${var.master_count}"
     cluster_fqdn       = "${local.cluster_fqdn}"
     docker_version     = "${local.docker_version}"
   }
 }
 
 data "template_file" "master_user_data_4" {
-  count    = "${local.master_resource_count}"
+  count    = "${var.master_count}"
   template = "${file("${path.module}/user_data/04_ig_spec.sh.tpl")}"
 
   vars {
@@ -29,7 +29,7 @@ data "template_file" "master_user_data_4" {
 }
 
 data "template_file" "master_user_data_5" {
-  count    = "${local.master_resource_count}"
+  count    = "${var.master_count}"
   template = "${file("${path.module}/user_data/05_kube_env.sh.tpl")}"
 
   vars {

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -99,3 +99,9 @@ variable "kubernetes_networking" {
 variable "master_k8s_cpu_threshold" {
   default = 80
 }
+
+# Local path to the SSH public key. It's not used effectively, but kops requires it
+variable "ssh_public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
+  type = "string"
+}

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -33,10 +33,9 @@ variable "public_subnet_cidr_blocks" {
   type = "list"
 }
 
-# Force single master. Can be used when a master per AZ is not required or if running
-# in a region with only 2 AZs.
-variable "force_single_master" {
-  default = false
+# Set the desired amount of master nodes. NB! It should be odd for a quorum : 1, 3, 5, etc.
+variable "master_count" {
+  default = 3
 }
 
 # Instance type for the master


### PR DESCRIPTION
This PR introduces several changes related to the detection of the count of k8s master instances and AZs where they should be bootstrapped.

* Set a desired amount of master explicitly with `master_count` variable.
This new approach allows to bootstrap any amount of masters regardless of the amount of AZs in
the particular region. The list of AZs for masters will be detected automatically depending on the `master_count`. If master_count is bigger that the amount of available AZs in the region, then some masters will be bootstrapped in the same AZ (kops handles that).
It also removes `force_single_master` since it becomes redundant. Use `master_count = 1` instead.

* Set "node-size" and "master-size" options for "kops create cluster" command
That is needed for the proper values being saved in the S3 kops state, which could make sense for doing `kops upgrade` in the future.

* Add `ssh_public_key_path` variable.
The default value is "~/.ssh/id_rsa.pub". It is passed to the "--ssh-public-key" argument of kops create cluster" command. If this argument is omitted, kops uses `"~/.ssh/id_rsa.pub"` and throws an error if this file is missing on the workstation.

* Disable "create_before_destroy" lifecycle rule for create_cluster resource
That will allow using "terraform taint" command for cluster re-creation.
"kops create cluster" command requires the cluster to be deleted first, so we need to switch the default terraform behavior to do destroy before create.
⚠️ _UPDATE:_ It still doesn't work as expected with `terraform taint` because of the existing issue of terraform: https://github.com/hashicorp/terraform/issues/14403
But there is a chance that it will be fixed, so the module will be prepared for this.
